### PR TITLE
Return subscription

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,12 +57,11 @@ class XMPP {
 
     on(type, callback){
         if (map[type]){
-            NativeAppEventEmitter.addListener(
+            return NativeAppEventEmitter.addListener(
                 map[type],callback);
         } else {
-            console.error("No registered type: "+type);
+            throw "No registered type: " + type;
         }
-
     }
 
     connect(username, password, auth = RNXMPP.SCRAMSHA1){


### PR DESCRIPTION
In order to clean up event subscriptions, the NativeAppEventEmitter.addListener should be returned.
