### PR TITLE
fix for dependency warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,10 @@ repositories {
     mavenCentral()
 }
 
+configurations {
+    all*.exclude group: 'xpp3', module: 'xpp3'
+}
+
 dependencies {
     compile "com.facebook.react:react-native:+"
     compile "org.igniterealtime.smack:smack-android:4.1.0"


### PR DESCRIPTION
This fixes:

```
WARNING: WARNING: Dependency xpp3:xpp3:1.1.4c is ignored for debug as it
may be conflicting with the internal version provided by Android. In
case of problem, please repackage it with jarjar to change the class
packages
```